### PR TITLE
Wrong syntax of a code snippet

### DIFF
--- a/completions/snippets/forms/classes.toml
+++ b/completions/snippets/forms/classes.toml
@@ -14,7 +14,7 @@ body = """
 class $1Form(forms.ModelForm):
     $0
     class Meta:
-        model = $1",
+        model = $1
         fields = ("$2",$3)
 """
 detail = "class $1Form(forms.ModelForm)"


### PR DESCRIPTION
class ArticleForm(forms.ModelForm):
    
    class Meta:
        model = Article
        fields = ("",)