### PR TITLE
Updated tags.json to support translate tag. Fixes #68

### DIFF
--- a/snippets/templates/tags.json
+++ b/snippets/templates/tags.json
@@ -389,12 +389,12 @@
         "prefix": "with_paste",
         "body": "{% with $1 as $2 %}${CLIPBOARD}{% endwith %}"
     },
-
-    "trans": {
-        "description": "{% trans \"\" %}",
-        "prefix": "trans",
-        "body": "{% trans \"${0:$SELECTION}\" %}"
-    },
+   
+    "translate": {
+        "description": "{% translate \"\" %}",
+        "prefix": "translate",
+        "body": "{% translate \"${0:$SELECTION}\" %}"
+    },    
 
     "trans_paste": {
         "description": "{% trans \"(paste)\" %}",


### PR DESCRIPTION
Django 3.1 changed trans to translate in template tags.