### PR TITLE
html files recognition automatically instead of manually configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,15 @@
 
 ## Usage
 
-Configure you file association for `Django HTML` in the **Language Mode** menu
-or drop this in your settings for more precision:
+Configure you file association for `Django HTML` in the **Language Mode** menu like below:
+1. Press `ctrl+shift+p`.
+2. Type `Update html files recognition in Django Projects`
+3. Press `Enter`
+
+<details>
+<summary>
+<i>Click to see what configs this plugin will use</i>
+</summary>
 
 ```json
 "files.associations": {
@@ -14,13 +21,9 @@ or drop this in your settings for more precision:
     "**/templates/**/*": "django-txt",
     "**/requirements{/**,*}.{txt,in}": "pip-requirements"
 },
+"emmet.includeLanguages": {"django-html": "html"}
 ```
-
-Emmet enthusiasts should have this to their configuration as well:
-
-```json
-"emmet.includeLanguages": {"django-html": "html"},
-```
+</details>
 
 Dealing with `django.po` files? Consider installing the [gettext extension](https://marketplace.visualstudio.com/items?itemName=mrorz.language-gettext).
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-django",
     "displayName": "Django",
     "description": "Beautiful syntax and scoped snippets for perfectionists with deadlines",
-    "version": "1.6.0",
+    "version": "1.6.1",
     "publisher": "batisteo",
     "license": "MIT",
     "icon": "images/vscode-django-icon.png",
@@ -36,7 +36,8 @@
     "activationEvents": [
         "onLanguage:django-html",
         "onLanguage:django-txt",
-        "onLanguage:python"
+        "onLanguage:python",
+        "onCommand:django.updateHtmlConfig"
     ],
     "main": "./out/extension",
     "scripts": {
@@ -48,8 +49,10 @@
         "test": "yarn run compile && node ./node_modules/vscode/bin/test"
     },
     "dependencies": {
+        "global": "^4.4.0",
         "path": "^0.12.7",
-        "toml": "^3"
+        "toml": "^3",
+        "vsce": "^1.88.0"
     },
     "devDependencies": {
         "@types/glob": "^7.1.3",
@@ -69,6 +72,10 @@
             {
                 "command": "extension.Message",
                 "title": "Message"
+            },
+            {
+                "command": "django.updateHtmlConfig",
+                "title": "Update html files recognition in Django Projects"
             }
         ],
         "languages": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,6 +14,7 @@ import {
     DjangoUrlCompletionItemProvider,
 } from './completions/completionItemProvider'
 import { postInitHook } from './utils';
+import { activateHtmlPatchSettings } from './htmlPatchSettings';
 
 export async function activate(context: ExtensionContext): Promise<void> {
     const definitions = new TemplatePathProvider()
@@ -45,6 +46,6 @@ export async function activate(context: ExtensionContext): Promise<void> {
 
     const djangoUrlSnippets = new DjangoUrlCompletionItemProvider()
     context.subscriptions.push(languages.registerCompletionItemProvider(djangoUrlSnippets.selector, djangoUrlSnippets))
-
+    activateHtmlPatchSettings(context);
     postInitHook();
 }

--- a/src/htmlPatchSettings.ts
+++ b/src/htmlPatchSettings.ts
@@ -1,0 +1,48 @@
+import * as vscode from "vscode";
+
+export interface GeneralObject {
+  [index: string]: any;
+}
+
+
+export const extractAsKeyValue = (object: GeneralObject) => ({
+  key: Object.keys(object)[0],
+  value: Object.values(object)[0],
+});
+
+
+export const htmlSettings = [
+  {
+    "files.associations": {
+      "**/*.html": "html",
+      "**/templates/**/*.html": "django-html",
+      "**/templates/**/*": "django-txt",
+      "**/requirements{/**,*}.{txt,in}": "pip-requirements",
+    },
+  },
+  {
+    "emmet.includeLanguages": { "django-html": "html" },
+  }
+] as GeneralObject[];
+
+const updateUserSettings = async (settings: GeneralObject[]) => {
+  settings.forEach(async (setting) => {
+    const { key, value } = extractAsKeyValue(setting);
+    await vscode.workspace
+      .getConfiguration()
+      .update(key, value, vscode.ConfigurationTarget.Global);
+  });
+};
+
+export async function activateHtmlPatchSettings(context: vscode.ExtensionContext) {
+  const showDialog = vscode.window.showInformationMessage;
+  let disposable = vscode.commands.registerCommand(
+    "django.updateHtmlConfig",
+    async () => {
+      console.log(JSON.stringify(htmlSettings, null, 1));
+      await updateUserSettings(htmlSettings);
+      showDialog("Html files recognition in Django Projects has been updated.");
+    }
+  );
+  context.subscriptions.push(disposable);
+}


### PR DESCRIPTION
HTML files recognized as Django Template in VS Code after installing this plugin, now in this version we can put custom settings for html files recognition in vscode settings.json automatically with a command, instead of manually configuration. change descriptions:
1. added:  src/htmlPatchSettings.ts, 
2. updated: src/extension.ts, package.json and README.md
3. command title: "Update html files recognition in Django Projects"