### PR TITLE
add web support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ package-lock.json
 .venv
 .env
 **/__pycache__
+.vscode-test/
+.vscode-test-web/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -31,6 +31,20 @@
 				"${workspaceFolder}/out/test/**/*.js"
 			],
 			"preLaunchTask": "npm: watch"
+		},
+		{
+			"name": "Run Web Extension",
+			"type": "pwa-extensionHost",
+			"debugWebWorkerHost": true,
+			"request": "launch",
+			"args": [
+				"--extensionDevelopmentPath=${workspaceFolder}",
+				"--extensionDevelopmentKind=web"
+			],
+			"outFiles": [
+				"${workspaceFolder}/out/**/*.js"
+			],
+			"preLaunchTask": "npm: compile-web"
 		}
 	]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -15,6 +15,15 @@
 				"kind": "build",
 				"isDefault": true
 			}
+		},
+		{
+			"type": "npm",
+			"script": "compile-web",
+			"group": "build",
+			"isBackground": true,
+			"problemMatcher": [
+				"$ts-webpack-watch"
+			]
 		}
 	]
 }

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,5 +1,6 @@
 .vscode/**
 .vscode-test/**
+.vscode-test-web/**
 out/test/**
 src/**
 .gitignore

--- a/package.json
+++ b/package.json
@@ -39,13 +39,18 @@
         "onLanguage:python"
     ],
     "main": "./out/extension",
+    "browser": "./out/extension-web",
     "scripts": {
         "vscode:prepublish": "yarn run compile",
         "compile": "tsc -p ./",
         "lint": "eslint src --ext ts",
         "watch": "tsc -watch -p ./",
         "pretest": "yarn run compile && yarn run lint",
-        "test": "yarn run compile && node ./node_modules/vscode/bin/test"
+        "test": "yarn run compile && node ./node_modules/vscode/bin/test",
+        "compile-web": "webpack",
+        "watch-web": "webpack",
+        "package-web": "webpack --mode production --devtool hidden-source-map",
+        "chrome": "vscode-test-web --browserType=chromium --extensionDevelopmentPath=. ."
     },
     "dependencies": {
         "path": "^0.12.7",
@@ -62,7 +67,11 @@
         "glob": "^7.1.6",
         "mocha": "^8.1.3",
         "typescript": "^4.0.2",
-        "vscode-test": "^1.4.0"
+        "vscode-test": "^1.4.0",
+        "ts-loader": "^9.2.2",
+        "webpack": "^5.38.1",
+        "webpack-cli": "^4.7.0",
+        "@vscode/test-web": "^0.0.11"
     },
     "contributes": {
         "commands": [

--- a/src/completions/base.ts
+++ b/src/completions/base.ts
@@ -15,7 +15,7 @@ import {
 } from 'vscode'
 
 import { PYTHON_SELECTOR } from '../constants'
-import { DjangoSnippet, readSnippets } from '../utils'
+import { DjangoSnippet, SnippetProvider } from '../utils'
 
 const settings = workspace.getConfiguration("django");
 
@@ -29,15 +29,15 @@ export class DjangoCompletionItemProvider implements CompletionItemProvider {
     files: string[] = []
     snippets: DjangoSnippet[] = []
 
-    loadSnippets() {
+    async loadSnippets(snippetPrvider: SnippetProvider) {
         if (! settings.snippets.use) return
         if (exclusions.some(word => this.directory.includes(word))) return
 
-        this.snippets = Array.prototype.concat(...this.files
-            .filter(file => ! exclusions.some(word => file.includes(word)))
-            .map(file => readSnippets(`${this.directory}/${file}`))
-        )
-        if (! settings.i18n) {
+        this.snippets = Array.prototype.concat(...await Promise.all(
+            this.files.filter(file => ! exclusions.some(word => file.includes(word)))
+                .map(file => snippetPrvider.readSnippets(`${this.directory}/${file}`))
+        ));
+        if (!settings.i18n) {
             this.snippets = this.snippets.map(snippet => {
                 snippet.body = snippet.body.replace(/_\("(\S*)"\)/g, '"$1"');
                 return snippet

--- a/src/completions/completionItemProvider.ts
+++ b/src/completions/completionItemProvider.ts
@@ -1,6 +1,7 @@
 'use strict';
 
 import { PYTHON_SELECTOR } from '../constants'
+import { SnippetProvider } from '../utils';
 import { DjangoCompletionItemProvider } from './base'
 
 
@@ -10,9 +11,9 @@ export class DjangoPythonCompletionItemProvider extends DjangoCompletionItemProv
     directory = 'python'
     files = ["imports.toml", "utils.toml"]
 
-    constructor () {
+    constructor (snippetPrvider: SnippetProvider) {
         super()
-        this.loadSnippets()
+        this.loadSnippets(snippetPrvider)
     }
 }
 
@@ -23,9 +24,9 @@ export class DjangoAdminCompletionItemProvider extends DjangoCompletionItemProvi
     directory = "admin"
     files = ["classes.toml", "imports.toml", "options.toml"]
 
-    constructor () {
+    constructor (snippetPrvider: SnippetProvider) {
         super()
-        this.loadSnippets()
+        this.loadSnippets(snippetPrvider)
     }
 }
 
@@ -36,9 +37,9 @@ export class DjangoFormCompletionItemProvider extends DjangoCompletionItemProvid
     directory = "forms"
     files = ["classes.toml", "imports.toml", "fields.toml", "fields-postgres.toml", "methods.toml"]
 
-    constructor () {
+    constructor (snippetPrvider: SnippetProvider) {
         super()
-        this.loadSnippets()
+        this.loadSnippets(snippetPrvider)
     }
 }
 
@@ -49,9 +50,9 @@ export class DjangoManagerCompletionItemProvider extends DjangoCompletionItemPro
     directory = "models"
     files = ["managers.toml"]
 
-    constructor () {
+    constructor (snippetPrvider: SnippetProvider) {
         super()
-        this.loadSnippets()
+        this.loadSnippets(snippetPrvider)
     }
 }
 
@@ -62,9 +63,9 @@ export class DjangoMigrationCompletionItemProvider extends DjangoCompletionItemP
     directory = "models"
     files = ["migrations.toml"]
 
-    constructor () {
+    constructor (snippetPrvider: SnippetProvider) {
         super()
-        this.loadSnippets()
+        this.loadSnippets(snippetPrvider)
     }
 }
 
@@ -75,9 +76,9 @@ export class DjangoModelCompletionItemProvider extends DjangoCompletionItemProvi
     directory = "models"
     files = ["classes.toml", "imports.toml", "fields.toml", "fields-postgres.toml", "methods.toml"]
 
-    constructor () {
+    constructor (snippetPrvider: SnippetProvider) {
         super()
-        this.loadSnippets()
+        this.loadSnippets(snippetPrvider)
     }
 }
 
@@ -88,9 +89,9 @@ export class DjangoViewCompletionItemProvider extends DjangoCompletionItemProvid
     directory = "views"
     files = ["classes.toml", "imports.toml", "methods.toml"]
 
-    constructor () {
+    constructor (snippetPrvider: SnippetProvider) {
         super()
-        this.loadSnippets()
+        this.loadSnippets(snippetPrvider)
     }
 }
 
@@ -101,9 +102,9 @@ export class DjangoTemplatetagsCompletionItemProvider extends DjangoCompletionIt
     directory = "templatetags"
     files = ["imports.toml", "methods.toml"]
 
-    constructor () {
+    constructor (snippetPrvider: SnippetProvider) {
         super()
-        this.loadSnippets()
+        this.loadSnippets(snippetPrvider)
     }
 }
 
@@ -114,8 +115,8 @@ export class DjangoUrlCompletionItemProvider extends DjangoCompletionItemProvide
     directory = "urls"
     files = ["imports.toml", "methods.toml", "regexes.toml"]
 
-    constructor () {
+    constructor (snippetPrvider: SnippetProvider) {
         super()
-        this.loadSnippets()
+        this.loadSnippets(snippetPrvider)
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,37 +13,39 @@ import {
     DjangoTemplatetagsCompletionItemProvider,
     DjangoUrlCompletionItemProvider,
 } from './completions/completionItemProvider'
-import { postInitHook } from './utils';
+import { postInitHook, SnippetProvider } from './utils';
 
 export async function activate(context: ExtensionContext): Promise<void> {
+    const snippetProvider = new SnippetProvider(context.extensionUri);
+
     const definitions = new TemplatePathProvider()
     context.subscriptions.push(languages.registerDefinitionProvider(definitions.selector, definitions))
 
-    const djangoPythonSnippets = new DjangoPythonCompletionItemProvider()
+    const djangoPythonSnippets = new DjangoPythonCompletionItemProvider(snippetProvider)
     context.subscriptions.push(languages.registerCompletionItemProvider(djangoPythonSnippets.selector, djangoPythonSnippets))
 
-    const djangoAdminSnippets = new DjangoAdminCompletionItemProvider()
+    const djangoAdminSnippets = new DjangoAdminCompletionItemProvider(snippetProvider)
     context.subscriptions.push(languages.registerCompletionItemProvider(djangoAdminSnippets.selector, djangoAdminSnippets))
 
-    const djangoFormSnippets = new DjangoFormCompletionItemProvider()
+    const djangoFormSnippets = new DjangoFormCompletionItemProvider(snippetProvider)
     context.subscriptions.push(languages.registerCompletionItemProvider(djangoFormSnippets.selector, djangoFormSnippets))
 
-    const djangoManagerSnippets = new DjangoManagerCompletionItemProvider()
+    const djangoManagerSnippets = new DjangoManagerCompletionItemProvider(snippetProvider)
     context.subscriptions.push(languages.registerCompletionItemProvider(djangoManagerSnippets.selector, djangoManagerSnippets))
 
-    const djangoMigrationSnippets = new DjangoMigrationCompletionItemProvider()
+    const djangoMigrationSnippets = new DjangoMigrationCompletionItemProvider(snippetProvider)
     context.subscriptions.push(languages.registerCompletionItemProvider(djangoMigrationSnippets.selector, djangoMigrationSnippets))
 
-    const djangoModelSnippets = new DjangoModelCompletionItemProvider()
+    const djangoModelSnippets = new DjangoModelCompletionItemProvider(snippetProvider)
     context.subscriptions.push(languages.registerCompletionItemProvider(djangoModelSnippets.selector, djangoModelSnippets))
 
-    const djangoViewSnippets = new DjangoViewCompletionItemProvider()
+    const djangoViewSnippets = new DjangoViewCompletionItemProvider(snippetProvider)
     context.subscriptions.push(languages.registerCompletionItemProvider(djangoViewSnippets.selector, djangoViewSnippets))
 
-    const djangoTemplatetagsSnippets = new DjangoTemplatetagsCompletionItemProvider()
+    const djangoTemplatetagsSnippets = new DjangoTemplatetagsCompletionItemProvider(snippetProvider)
     context.subscriptions.push(languages.registerCompletionItemProvider(djangoTemplatetagsSnippets.selector, djangoTemplatetagsSnippets))
 
-    const djangoUrlSnippets = new DjangoUrlCompletionItemProvider()
+    const djangoUrlSnippets = new DjangoUrlCompletionItemProvider(snippetProvider)
     context.subscriptions.push(languages.registerCompletionItemProvider(djangoUrlSnippets.selector, djangoUrlSnippets))
 
     postInitHook();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,9 +1,8 @@
 
-import path = require("path");
-import fs = require("fs");
 import toml = require("toml");
 
-const folder = path.resolve(__dirname, "../completions/snippets/");
+import vscode = require("vscode");
+import { TextDecoder } from "util";
 
 export interface DjangoSnippet {
     prefix: string
@@ -12,9 +11,19 @@ export interface DjangoSnippet {
     description: string
 }
 
+export class SnippetProvider {
+    constructor(private extensionUri: vscode.Uri) {
+    }
+    async readSnippets(name: string): Promise<DjangoSnippet[]> {
 
-export function readSnippets(name: string): DjangoSnippet[] {
-    return toml.parse(fs.readFileSync(path.resolve(folder, name), "utf-8")).snippets
+        const location = vscode.Uri.joinPath(this.extensionUri, 'completions/snippets', name)
+
+        const buffer = await vscode.workspace.fs.readFile(location);
+        const str = new TextDecoder("utf-8").decode(buffer);
+
+        return toml.parse(str).snippets;
+    }
 }
+
 
 export async function postInitHook(): Promise<void> { }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,52 @@
+const path = require('path');
+const webpack = require('webpack');
+
+const configWeb = /** @type WebpackConfig */ {
+  mode: 'none', // this leaves the source code as close as possible to the original (when packaging we set this to 'production')
+  target: 'webworker', // extensions run in a webworker context
+  entry: {
+    'extension-web': './src/extension.ts' // source of the web extension main file
+  },
+  output: {
+    filename: '[name].js',
+    path: path.join(__dirname, 'out'),
+    libraryTarget: 'commonjs'
+  },
+  resolve: {
+    mainFields: ['browser', 'module', 'main'], // look for `browser` entry point in imported node modules
+    extensions: ['.ts', '.js'], // support ts-files and js-files
+    alias: {
+      // provides alternate implementation for node module and source files
+    },
+    fallback: {
+      // Webpack 5 no longer polyfills Node.js core modules automatically.
+      // see https://webpack.js.org/configuration/resolve/#resolvefallback
+      // for the list of Node.js core module polyfills.
+      'assert': require.resolve('assert')
+    }
+  },
+  module: {
+    rules: [{
+      test: /\.ts$/,
+      exclude: /node_modules/,
+      use: [{
+          loader: 'ts-loader'
+      }]
+    }]
+  },
+  plugins: [
+    new webpack.ProvidePlugin({
+      process: 'process/browser', // provide a shim for the global `process` variable
+    }),
+  ],
+  externals: {
+    'vscode': 'commonjs vscode', // ignored because it doesn't exist
+  },
+  performance: {
+    hints: false
+  },
+  devtool: 'source-map' // create a source map that points to the original source file
+};
+
+
+module.exports = [ configWeb ];


### PR DESCRIPTION
Hi @batisteo 

:wave: I'm Martin and I'm a dev in the VS Code team. We recently launched VS Code for the web with [github.dev](https://docs.github.com/en/codespaces/developing-in-codespaces/web-based-editor).

In VS Code for the web, both UI and extension host run inside the browser. 

vscode-django was one of our test cases, and this PR shows how we got it to run. I hope you are interested to adopt and the PR is useful. 

Web extension have a different main file than regular extensions. It's listed under the `browser` property. Web extensions can't load any modules except `vscode`. So all needs to be packaged and statically bundled.

 - I added webpack file for the web main entry file and added the `browser` entry
 - I replaced the use of `fs` with `vscode.workspace.fs`

To try it out:
- `yarn`
- run the new launch config `Launch Web Extension`. This will open a regular VS Code Desktop but with the vscode-django extension running in a web worker. To verify this, use the extension and run command `Show Running Extensions`. It says `web worker` next to `vscode-django`
- try it out in a browser with: `yarn chrome`