### PR TITLE
Fixed syntax highlighting in style tag

### DIFF
--- a/syntaxes/django-html.tmLanguage.json
+++ b/syntaxes/django-html.tmLanguage.json
@@ -463,6 +463,9 @@
             },
             {
               "include": "source.css.django"
+            },
+            {
+              "include": "source.css"
             }
           ],
           "beginCaptures": {

--- a/syntaxes/django-html.tmLanguage.json
+++ b/syntaxes/django-html.tmLanguage.json
@@ -646,6 +646,97 @@
       "name": "meta.tag.inline.any.html",
       "patterns": [
         {
+          "begin": "(?i:style)",
+          "beginCaptures": {
+            "0": {
+              "name": "entity.other.attribute-name.html"
+            }
+          },
+          "end": "(?=\\s*+[^=\\s])",
+          "name": "meta.attribute.style.html",
+          "patterns": [
+            {
+              "begin": "=",
+              "beginCaptures": {
+                "0": {
+                  "name": "punctuation.separator.key-value.html"
+                }
+              },
+              "end": "(?<=[^\\s=])(?!\\s*=)|(?=/?>)",
+              "patterns": [
+                {
+                  "begin": "(?=[^\\s=<>`/]|/(?!>))",
+                  "end": "(?!\\G)",
+                  "name": "meta.embedded.line.css",
+                  "patterns": [
+                    {
+                      "captures": {
+                        "0": {
+                          "name": "source.css.embedded.html"
+                        }
+                      },
+                      "match": "([^\\s\"'=<>`/]|/(?!>))+",
+                      "name": "string.unquoted.html"
+                    },
+                    {
+                      "begin": "\"",
+                      "beginCaptures": {
+                        "0": {
+                          "name": "punctuation.definition.string.begin.html"
+                        }
+                      },
+                      "contentName": "source.css.embedded.html",
+                      "end": "(\")",
+                      "endCaptures": {
+                        "0": {
+                          "name": "punctuation.definition.string.end.html"
+                        },
+                        "1": {
+                          "name": "source.css-ignored-vscode"
+                        }
+                      },
+                      "name": "string.quoted.double.html",
+                      "patterns": [
+                        {
+                          "include": "source.css#rule-list-innards"
+                        }
+                      ]
+                    },
+                    {
+                      "begin": "'",
+                      "beginCaptures": {
+                        "0": {
+                          "name": "punctuation.definition.string.begin.html"
+                        }
+                      },
+                      "contentName": "source.css.embedded.html",
+                      "end": "(')",
+                      "endCaptures": {
+                        "0": {
+                          "name": "punctuation.definition.string.end.html"
+                        },
+                        "1": {
+                          "name": "source.css-ignored-vscode"
+                        }
+                      },
+                      "name": "string.quoted.single.html",
+                      "patterns": [
+                        {
+                          "include": "source.css#rule-list-innards"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "match": "=",
+                  "name": "invalid.illegal.unexpected-equals-sign.html"
+                }
+              ]
+            }
+          ]
+        },
+        {
           "include": "#django-stuff"
         },
         {


### PR DESCRIPTION
Fix for  #43.
Added an extra include pattern (source.css) in the style tag definition. Doing so enables syntax highlighting for embedded css in the style tag. However, the embedded color preview/picker is not fixed, just the syntax highlighting.
It doesn't fix syntax highlighting for element style attributes.