### PR TITLE
fix(django-txt): fix `django-txt` incorrectly applying to all files in /templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
                     "django"
                 ],
                 "filenamePatterns": [
-                    "**/templates/**/*"
+                    "**/templates/**/*.txt"
                 ],
                 "firstLine": "{%",
                 "configuration": "./language-configuration.json"


### PR DESCRIPTION
> NO ISSUE

- In my Django app, we allow users to create custom templates for pdf's, and perhaps incorrectly call this app `templates`
- Regardless, `django-txt` should only apply to `.txt` files explicitly, otherwise any file within `/templates/` vscode incorrectly assume it is a `.txt` file for styling purposes.