### PR TITLE
Let go to Jinja template file

### DIFF
--- a/src/providers/definitionProvider.ts
+++ b/src/providers/definitionProvider.ts
@@ -43,7 +43,7 @@ export class TemplatePathProvider implements DefinitionProvider {
             search = workspace.asRelativePath(resolve(dirname(document.uri.path), path))
         } else if (match) {
             path = match[1]
-            search = `**/templates/${path}`
+            search = `**/{templates,jinja2}/${path}`
         } else {
             return Promise.resolve(null)
         }


### PR DESCRIPTION
When encoutering a path to Jinja2 template file, convert it to "go to" link, too.