### PR TITLE
Minor tags improvements + new view method snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ### Go to definition in templates
 
-Ctrl-click or press F12 on the template path in a `include` or `extends` tag
+Ctrl+click (cmd+click on MacOS) or press F12 on the template path in a `include` or `extends` tag
 to jump to this template
 
 ### Snippets
@@ -19,7 +19,7 @@ to jump to this template
 
 ### Improved syntax
 
-- Adds the filetype `django-html` 
+- Adds the filetype `django-html`
 - Adds the filetype `django-txt` for email templates.
 - Better syntax with more operators and default keywords:
   - Known default tags and filters
@@ -41,7 +41,7 @@ Consider installing the [Gettext extension](https://marketplace.visualstudio.com
 
 Add the following item to the **Emmet: Include Languages** settings:
 
-|     Item      | Value  |
+| Item          | Value  |
 | ------------- | ------ |
 | `django-html` | `html` |
 
@@ -71,7 +71,6 @@ code .
 
 It’s better to have [TSlint](https://marketplace.visualstudio.com/items?itemName=eg2.tslint) installed.
 
-
 ### Launching the extension debugger
 
 Make sure you have this snippet in `.vscode/launch.json`:
@@ -98,4 +97,3 @@ Press <kbd>F5</kbd> or click on Debug then Start (▶️) to launch the extensio
 Hack around
 
 Press <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>F5</kbd> or 🔄 to reload.
-

--- a/completions/snippets/views/methods.toml
+++ b/completions/snippets/views/methods.toml
@@ -29,7 +29,7 @@ def get_queryset(self):
 prefix = "get_template_names"
 detail = "get_template_names(self)"
 body = """
-def get_queryset(self) -> list[str]:
+def get_template_names(self) -> list[str]:
     if ${1:condition}:
         return ["$2"]
     return super().get_template_names()

--- a/completions/snippets/views/methods.toml
+++ b/completions/snippets/views/methods.toml
@@ -11,9 +11,9 @@ def dispatch(self, request, *args, **kwargs):
 prefix = "get_context_data"
 detail = "get_context_data(self, **kwargs)"
 body = """
-def get_context_data(self, **kwargs):
+def get_context_data(self, **kwargs) -> dict[str, Any]:
     context = super().get_context_data(**kwargs)
-    context["$1"] = $0
+    context["$1"] = $2
     return context
 """
 
@@ -23,4 +23,32 @@ detail = "get_queryset(self)"
 body = """
 def get_queryset(self):
     ${1:return} super().get_queryset()$0
+"""
+
+[[snippets]]
+prefix = "get_template_names"
+detail = "get_template_names(self)"
+body = """
+def get_queryset(self) -> list[str]:
+    if ${1:condition}:
+        return ["$2"]
+    return super().get_template_names()
+"""
+
+[[snippets]]
+prefix = "form_valid"
+detail = "form_valid(self, form)"
+body = """
+def form_valid(self, form):
+    ${1:form}
+    return super().form_valid(form)
+"""
+
+[[snippets]]
+prefix = "form_invalid"
+detail = "form_invalid(self, form)"
+body = """
+def form_invalid(self, form):
+    response = super().form_invalid(form)
+    ${1:response}
 """

--- a/snippets/templates/tags.json
+++ b/snippets/templates/tags.json
@@ -30,7 +30,7 @@
     },
 
     "block_unnamed": {
-        "description": "{% block name %}{% endblock %},
+        "description": "{% block name %}{% endblock %}",
         "prefix": "block_unnamed",
         "body": "{% block $1 %}$0{% endblock %}"
     },
@@ -303,10 +303,10 @@
     },
 
     "static": {
-        "prefix": "static",
+        "prefix": "{% static %}",
         "description": "static",
         "body": "{% static \"${1:$SELECTION}\" %}"
-    }
+    },
 
     "tag": {
         "description": "{% tag %}",
@@ -492,5 +492,5 @@
         "description": "{% with key=value %} (paste)",
         "prefix": "with_paste",
         "body": "{% with $1=$2 %}${CLIPBOARD}{% endwith %}"
-    },
+    }
 }

--- a/snippets/templates/tags.json
+++ b/snippets/templates/tags.json
@@ -1,24 +1,6 @@
 {
     "_comment" : "This section is autocomplete for django template tags",
 
-    "variable": {
-        "description": "{{ var }}",
-        "prefix": "variable",
-        "body": "{{ $1 }}"
-    },
-
-    "super": {
-        "description": "{{ block.super }}",
-        "prefix": "super",
-        "body": "{{ block.super }}"
-    },
-
-    "tag": {
-        "description": "{% tag %}",
-        "prefix": "tag",
-        "body": "{% $1 %}"
-    },
-
     "autoescape": {
         "description": "{% autoescape %}",
         "prefix": "autoescape",
@@ -42,14 +24,14 @@
     },
 
     "block": {
-        "description": "{% block %}",
+        "description": "{% block name %}{% endblock name %}",
         "prefix": "block",
         "body": "{% block $1 %}$0{% endblock $1 %}"
     },
 
-    "blok": {
-        "description": "{% block %} (unnamed endblock)",
-        "prefix": "blok",
+    "block_unnamed": {
+        "description": "{% block name %}{% endblock %},
+        "prefix": "block_unnamed",
         "body": "{% block $1 %}$0{% endblock %}"
     },
 
@@ -57,6 +39,12 @@
         "description": "{% endblock %}",
         "prefix": "endblock",
         "body": "{% endblock %}"
+    },
+
+    "super": {
+        "description": "{{ block.super }}",
+        "prefix": "super",
+        "body": "{{ block.super }}"
     },
 
     "comment_inline": {
@@ -112,14 +100,19 @@
     },
 
     "extends": {
-        "description": "{% extends %}",
+        "description": "{% extends "template_name.html" %}",
         "prefix": "extends",
-        "body": "{% extends \"$1\" %}$0"
-        "body": "{% extends \"$1\" %}$0"
+        "body": "{% extends \"$1.html\" %}$0"
+    },
+
+    "extends_var": {
+        "description": "{% extends variable %}",
+        "prefix": "extends_variable",
+        "body": "{% extends $1 %}$0"
     },
 
     "filter": {
-        "description": "{% filter %}",
+        "description": "{% filter filter_name %}",
         "prefix": "filter",
         "body": "{% filter $1 %}$0{% endfilter %}"
     },
@@ -309,35 +302,148 @@
         "body": "{% endspaceless %}"
     },
 
+    "static": {
+        "prefix": "static",
+        "description": "static",
+        "body": "{% static \"${1:$SELECTION}\" %}"
+    }
+
+    "tag": {
+        "description": "{% tag %}",
+        "prefix": "tag",
+        "body": "{% $1 %}"
+    },
+
     "templatetag": {
         "description": "{% templatetag %}",
         "prefix": "templatetag",
         "body": "{% templatetag ${1|openblock,closeblock,openvariable,closevariable,openbrace,closebrace,opencomment,closecomment|} %}"
     },
 
+    "trans": {
+        "description": "{% trans \"text to translate\" %}",
+        "prefix": "trans",
+        "body": "{% trans \"${0:$SELECTION}\" %}"
+    },
+
+    "trans_paste": {
+        "description": "{% trans \"(paste)\" %}",
+        "prefix": "trans_paste",
+        "body": "{% trans \"${CLIPBOARD}\" %}"
+    },
+
+    "blocktrans": {
+        "description": "{% blocktrans %}text to translate{% endblocktrans %}",
+        "prefix": "blocktrans",
+        "body": "{% blocktrans %}$0{% endblocktrans %}"
+    },
+
+    "blocktrans_paste": {
+        "description": "{% blocktrans %}(paste){% endblocktrans %}",
+        "prefix": "blocktrans_paste",
+        "body": [
+            "{% blocktrans ${2:trimmed }%}",
+            "$0${CLIPBOARD}",
+            "{% endblocktrans %}"
+        ]
+    },
+
+    "blocktrans_with": {
+        "description": "{% blocktrans with %}text to translate{% endblocktrans %}",
+        "prefix": "blocktrans_with",
+        "body": "{% blocktrans with $1=$2 ${3:trimmed }%}$0{% endblocktrans %}"
+    },
+
+    "blocktrans_with_paste": {
+        "description": "{% blocktrans with %}(paste){% endblocktrans %}",
+        "prefix": "blocktrans_with_paste",
+        "body": ["{% blocktrans with $1=$2 ${3:trimmed }%}",
+            "$0${CLIPBOARD}",
+            "{% endblocktrans %}"
+        ]
+    },
+
+    "translate": {
+        "description": "{% translate \"text to translate\" %}",
+        "prefix": "translate",
+        "body": "{% translate \"${0:$SELECTION}\" %}"
+    },
+
+    "translate_paste": {
+        "description": "{% translate \"(paste)\" %}",
+        "prefix": "translate_paste",
+        "body": "{% translate \"${CLIPBOARD}\" %}"
+    },
+
+    "blocktranslate": {
+        "description": "{% blocktranslate %}text to translate{% endblocktranslate %}",
+        "prefix": "blocktranslate",
+        "body": "{% blocktranslate %}$0{% endblocktranslate %}"
+    },
+
+    "blocktranslate_paste": {
+        "description": "{% blocktranslate %}(paste){% endblocktranslate %}",
+        "prefix": "blocktranslate_paste",
+        "body": [
+            "{% blocktranslate ${2:trimmed }%}",
+            "$0${CLIPBOARD}",
+            "{% endblocktranslate %}"
+        ]
+    },
+
+    "blocktranslate_with": {
+        "description": "{% blocktranslate with %}text to translate{% endblocktranslate %}",
+        "prefix": "blocktranslate_with",
+        "body": "{% blocktranslate with $1=$2 ${3:trimmed }%}$0{% endblocktranslate %}"
+    },
+
+    "blocktranslate_with_paste": {
+        "description": "{% blocktranslate with %}(paste){% endblocktranslate %}",
+        "prefix": "blocktranslate_with_paste",
+        "body": ["{% blocktranslate with $1=$2 ${3:trimmed }%}",
+            "$0${CLIPBOARD}",
+            "{% endblocktranslate %}"
+        ]
+    },
+
     "url": {
-        "description": "{% url %}",
+        "description": "{% url \"some-url-name\" %}",
         "prefix": "url",
-        "body": "{% url \"$1\" %}"
         "body": "{% url \"$1\" %}"
     },
 
     "urlpk": {
-        "description": "{% url pk=object.pk %}",
+        "description": "{% url \"some-url-name\" pk=object.pk %}",
         "prefix": "urlpk",
-        "body": "{% url \"$1\" pk=${2:${3:object}.pk} %}"
         "body": "{% url \"$1\" pk=${2:${3:object}.pk} %}"
     },
 
     "urlslug": {
-        "description": "{% url slug=object.slug %}",
+        "description": "{% url \"some-url-name\" slug=object.slug %}",
         "prefix": "urlslug",
-        "body": "{% url \"$1\" slug=${2:${3:object}.slug} %}"
         "body": "{% url \"$1\" slug=${2:${3:object}.slug} %}"
     },
 
+    "urlvar": {
+        "description": "{% url \"some-url-name\" as the_url %}",
+        "prefix": "urlvar",
+        "body": "{% url \"$1\" as $2 %}"
+    },
+
+    "variable": {
+        "description": "{{ variable }}",
+        "prefix": "variable",
+        "body": "{{ $1 }}"
+    },
+
+    "variable_default": {
+        "description": "{{ variable|default:\"default value\" }}",
+        "prefix": "variable_default",
+        "body": "{{ $1|default:\"$2\" }}"
+    },
+
     "verbatim": {
-        "description": "{% verbatim %}",
+        "description": "{% verbatim name %}some content{% endverbatim name %}",
         "prefix": "verbatim",
         "body": "{% verbatim $1 %}$0{% endverbatim $1 %}"
     },
@@ -361,9 +467,9 @@
     },
 
     "with": {
-        "description": "{% with %}",
+        "description": "{% with key=value %}",
         "prefix": "with",
-        "body": "{% with $1 as $2 %}$0{% endwith %}"
+        "body": "{% with $1=$2 %}$0{% endwith %}"
     },
 
     "endwith": {
@@ -373,110 +479,18 @@
     },
 
     "with_selection": {
-        "description": "{% with as %} (selection)",
+        "description": "{% with key=value %} (selection)",
         "prefix": "with_selection",
         "body": [
-            "$0{% with $1 as $2 %}",
+            "$0{% with $1=$2 %}",
             "\t${TM_SELECTED_TEXT}",
             "$0{% endwith %}"
         ]
     },
 
     "with_paste": {
-        "description": "{% with as %} (paste)",
+        "description": "{% with key=value %} (paste)",
         "prefix": "with_paste",
-        "body": "{% with $1 as $2 %}${CLIPBOARD}{% endwith %}"
+        "body": "{% with $1=$2 %}${CLIPBOARD}{% endwith %}"
     },
-
-    "trans": {
-        "description": "{% trans \"\" %}",
-        "prefix": "trans",
-        "body": "{% trans \"${0:$SELECTION}\" %}"
-    },
-
-    "trans_paste": {
-        "description": "{% trans \"(paste)\" %}",
-        "prefix": "trans_paste",
-        "body": "{% trans \"${CLIPBOARD}\" %}"
-    },
-
-    "blocktrans": {
-        "description": "{% blocktrans %}{% endblocktrans %}",
-        "prefix": "blocktrans",
-        "body": "{% blocktrans %}$0{% endblocktrans %}"
-    },
-
-    "blocktrans_paste": {
-        "description": "{% blocktrans %}(paste){% endblocktrans %}",
-        "prefix": "blocktrans_paste",
-        "body": [
-            "{% blocktrans ${2:trimmed }%}",
-            "$0${CLIPBOARD}",
-            "{% endblocktrans %}"
-        ]
-    },
-
-    "blocktrans_with": {
-        "description": "{% blocktrans with %}{% endblocktrans %}",
-        "prefix": "blocktrans_with",
-        "body": "{% blocktrans with $1=$2 ${3:trimmed }%}$0{% endblocktrans %}"
-    },
-
-    "blocktrans_with_paste": {
-        "description": "{% blocktrans with %}(paste){% endblocktrans %}",
-        "prefix": "blocktrans_with_paste",
-        "body": ["{% blocktrans with $1=$2 ${3:trimmed }%}",
-            "$0${CLIPBOARD}",
-            "{% endblocktrans %}"
-        ]
-    },
-
-    "translate": {
-        "description": "{% translate \"\" %}",
-        "prefix": "translate",
-        "body": "{% translate \"${0:$SELECTION}\" %}"
-    },
-
-    "translate_paste": {
-        "description": "{% translate \"(paste)\" %}",
-        "prefix": "translate_paste",
-        "body": "{% translate \"${CLIPBOARD}\" %}"
-    },
-
-    "blocktranslate": {
-        "description": "{% blocktranslate %}{% endblocktranslate %}",
-        "prefix": "blocktranslate",
-        "body": "{% blocktranslate %}$0{% endblocktranslate %}"
-    },
-
-    "blocktranslate_paste": {
-        "description": "{% blocktranslate %}(paste){% endblocktranslate %}",
-        "prefix": "blocktranslate_paste",
-        "body": [
-            "{% blocktranslate ${2:trimmed }%}",
-            "$0${CLIPBOARD}",
-            "{% endblocktranslate %}"
-        ]
-    },
-
-    "blocktranslate_with": {
-        "description": "{% blocktranslate with %}{% endblocktranslate %}",
-        "prefix": "blocktranslate_with",
-        "body": "{% blocktranslate with $1=$2 ${3:trimmed }%}$0{% endblocktranslate %}"
-    },
-
-    "blocktranslate_with_paste": {
-        "description": "{% blocktranslate with %}(paste){% endblocktranslate %}",
-        "prefix": "blocktranslate_with_paste",
-        "body": ["{% blocktranslate with $1=$2 ${3:trimmed }%}",
-            "$0${CLIPBOARD}",
-            "{% endblocktranslate %}"
-        ]
-    },
-
-    "static": {
-        "prefix": "static",
-        "description": "static",
-        "body": "{% static \"${1:$SELECTION}\" %}"
-    }
 }

--- a/snippets/templates/tags.json
+++ b/snippets/templates/tags.json
@@ -100,7 +100,7 @@
     },
 
     "extends": {
-        "description": "{% extends "template_name.html" %}",
+        "description": "{% extends \"template_name.html\" %}",
         "prefix": "extends",
         "body": "{% extends \"$1.html\" %}$0"
     },


### PR DESCRIPTION
- sorted tags to be in line with the Django docs
- added tags urlvar, variable_default
- some tag description adjustments
- [tag with new usage with `=` instead of `as`](https://docs.djangoproject.com/en/4.2/ref/templates/builtins/#with)
- removed duplicate `body` keys in tags
- new view method snippets get_template_names(), [form_valid() and form_invalid()](https://docs.djangoproject.com/en/4.2/topics/class-based-views/generic-editing/)