### PR TITLE
fix: json syntax error in tags.json

### DIFF
--- a/snippets/templates/tags.json
+++ b/snippets/templates/tags.json
@@ -218,15 +218,15 @@
     },
 
     "elif": {
-        "description": "{% elif condition %}"
+        "description": "{% elif condition %}",
         "prefix": "elif",
-        "body": "{% elif $1 %}",
+        "body": "{% elif $1 %}"
     },
 
     "else": {
-        "description": "{% else %}"
+        "description": "{% else %}",
         "prefix": "else",
-        "body": "{% else %}",
+        "body": "{% else %}"
     },
 
     "endif": {


### PR DESCRIPTION
Hi, I have fixed a syntax error in the json file for the `tags.json` snippet.