### PR TITLE
feat: allow jumping to django cotton components definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,6 +149,11 @@
           "type": "boolean",
           "default": true,
           "description": "Seldom show notifications about this extension"
+        },
+        "djangoCotton.componentFolder": {
+        "type": "string",
+        "default": "templates/cotton",
+        "description": "Path for Django Cotton component templates"
         }
       }
     }


### PR DESCRIPTION
[django-cotton](https://github.com/wrabit/django-cotton) allows developers to create reusable and flexible UI components. This PR aims to support going to the django-cotton components definition.

Components are by default placed inside the `templates/cotton` folder but users can [override](https://github.com/wrabit/django-cotton?tab=readme-ov-file#usage-basics) this in their settings.

I'd love to hear feedback on this :) Thank you.